### PR TITLE
lib: Remove println in draw_image()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,13 +213,6 @@ impl Oled {
             for (row, row_data) in page_data.chunks(OLED_WIDTH as usize).enumerate() {
                 for (column, pixel) in row_data.iter().enumerate() {
                     let pixel = if *pixel >= threshold { 1 } else { 0 };
-                    println!(
-                        "page: {}, row: {}, column: {}, write offset: {}",
-                        page,
-                        row,
-                        column,
-                        (page * OLED_WIDTH as usize) + column
-                    );
                     write_page[(page * OLED_WIDTH as usize) + column] |= pixel << row;
                 }
             }


### PR DESCRIPTION
This slows down the rendering and creates a lot of spam on the console.